### PR TITLE
update changelog for 0.1.1

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -6,7 +6,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  binder:
+  rtd:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-> ## 0.1.1 (Unreleased)
+> ## 0.1.2 (Unreleased)
 >
-> - [#12] adds an `mkdocs` plugin, available with `urljsf[mkdocs]`
->
-> [#12]: https://github.com/deathbeds/urljsf/pull/12
+> TBD
+
+## [0.1.1](https://github.com/deathbeds/urljsf/releases/tag/v0.1.1)
+
+- [#12] adds an `mkdocs` plugin, available with `pip install urljsf[mkdocs]` or
+  `conda install -c conda-forge urljsf-with-mkdocs`
+
+[#12]: https://github.com/deathbeds/urljsf/pull/12
 
 ## [0.1.0](https://github.com/deathbeds/urljsf/releases/tag/v0.1.0)
 


### PR DESCRIPTION
## References

- for #13 

## Code changes

- [x] promote `0.1.1` 
- [x] add `0.1.2 (unreleased)`
- [x] fix badge action name 

## User-facing changes

- n/a

## Backwards-incompatible changes

- n/a