### PR TITLE
add copy button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
-> ## 0.1.2 (Unreleased)
->
-> - [#19] fixes some schema descriptions
->
-> [#19]: https://github.com/deathbeds/urljsf/pull/19
+<details>
+<summary>Unreleased</summary>
+
+## 0.1.2
+
+- [#19] fixes some schema descriptions
+- [#20] adds a copy-to-clipboard button to all markdown-rendered `pre` tags
+
+[#19]: https://github.com/deathbeds/urljsf/pull/19
+[#20]: https://github.com/deathbeds/urljsf/pull/20
+
+</details>
 
 ## [0.1.1](https://github.com/deathbeds/urljsf/releases/tag/v0.1.1)
 

--- a/atest/suites/01_docs/002_installer.robot
+++ b/atest/suites/01_docs/002_installer.robot
@@ -20,6 +20,7 @@ ${CSS_LICENSE}          ${CSS_U_DATALIST} input[id$="_license"]
 ${CSS_LICENSE_CHECK}    ${CSS_U_DATALIST} input[id$="_license__datalist-check"]
 ${GOOD_LICENSE}         BSD-3-Clause
 ${BAD_LICENSE}          WTPL
+${CSS_COPY_BUTTON}      .urljsf-copybutton
 
 
 *** Test Cases ***
@@ -66,6 +67,10 @@ Verify Installer URL
     ${from_toml} =    TOML.Loads    ${raw}
     ${expected} =    Get TOML Fixture    002_installer.toml
     Should Be JSON Equivalent    ${from_toml}    ${expected}
+    ${copy} =    Set Variable    css:${CSS_COPY_BUTTON}
+    Click Element    ${copy}
+    Wait Until Element Contains    ${copy}    ok
+    Wait Until Element Contains    ${copy}    copy
 
 Verify Installer Download
     [Documentation]    Verify downloaded file

--- a/docs/use/advanced/templates.md
+++ b/docs/use/advanced/templates.md
@@ -22,6 +22,29 @@ Each `template` gets an object of this form:
 }
 ```
 
+## Markdown
+
+Most non-`url` templates are rendered as [Markdown][md].
+
+Much of [GitHub flavored Markdown][gfm] is supported, but not platform-specific features
+like magic `#{issue}` transforms and `mermaid` fenced code blocks. Indeed, no syntax
+highlighting is supported, so generally any fence info will be discarded.
+
+[gfm]: https://github.github.com/gfm
+[md]: https://daringfireball.net/projects/markdown
+
+### Copy Code
+
+All `pre` tags (generated with triple ticks, tildes, etc) will be rendered with a `copy`
+button.
+
+This helps for URL-based workflows that don't allow for populating key parameters such
+as GitLab's `/new/` URL, or otherwise complex ones (GitHub's `/edit/`).
+
+In this case, it is recommended to provide a [`below_{form}`](#below-form) template
+which shows the file content, with narrative describing how to copy the code and what to
+do with it.
+
 ### Special Templates
 
 A few well-known template names and patterns are used globally.

--- a/js/src/components/array-template.tsx
+++ b/js/src/components/array-template.tsx
@@ -17,6 +17,7 @@ import {
 import Markdown from 'markdown-to-jsx';
 
 import { useMarkdown } from '../utils.js';
+import { MD_OPTIONS } from './markdown.js';
 
 export function ArrayFieldTemplate<
   T = any,
@@ -62,7 +63,7 @@ export function ArrayFieldTemplate<
 
   let richDescription =
     description && useMarkdown(uiOptions) ? (
-      <Markdown>{description}</Markdown>
+      <Markdown options={MD_OPTIONS}>{description}</Markdown>
     ) : (
       description
     );

--- a/js/src/components/check-item.tsx
+++ b/js/src/components/check-item.tsx
@@ -4,6 +4,8 @@ import type { RJSFValidationError } from '@rjsf/utils';
 
 import Markdown from 'markdown-to-jsx';
 
+import { MD_OPTIONS } from './markdown.js';
+
 export function CheckItem(props: CheckItemProps): JSX.Element {
   let result: string;
   if (Array.isArray(props.result)) {
@@ -25,14 +27,20 @@ export function CheckItem(props: CheckItemProps): JSX.Element {
           disabled
         ></input>
         <label className="form-check-label">
-          <em>{props.markdown ? <Markdown>{props.label}</Markdown> : props.label}</em>
+          <em>
+            {props.markdown ? (
+              <Markdown options={MD_OPTIONS}>{props.label}</Markdown>
+            ) : (
+              props.label
+            )}
+          </em>
         </label>
       </div>
       {!result ? (
         <></>
       ) : props.markdown ? (
         <div>
-          <Markdown>{result}</Markdown>
+          <Markdown options={MD_OPTIONS}>{result}</Markdown>
         </div>
       ) : (
         result

--- a/js/src/components/copy-paste-pre.tsx
+++ b/js/src/components/copy-paste-pre.tsx
@@ -1,0 +1,77 @@
+// Copyright (C) urljsf contributors.
+// Distributed under the terms of the Modified BSD License.
+import { useState } from 'react';
+
+const PRE_STYLE = { position: 'relative' };
+
+type TPreProps = React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLPreElement>,
+  HTMLPreElement
+>;
+
+const COPY_STYLE = {
+  position: 'absolute',
+  top: '0.25em',
+  right: '0.25em',
+  opacity: 0.8,
+};
+
+const NOT_YET = 0;
+const COPIED = 1;
+const ERRORED = 2;
+
+const STATE_ICON = ['primary', 'success', 'warning'];
+const STATE_LABEL = ['copy', 'ok', 'error'];
+
+export function CopyPastePre(props: TPreProps): JSX.Element {
+  const button: JSX.Element[] = [];
+
+  const text = `${(props.children as any)?.props?.children || ''}`.trim();
+
+  if (text) {
+    const [copyState, setCopyState] = useState(NOT_YET);
+    const btnClass = `urljsf-copybutton btn btn-${STATE_ICON[copyState]}`;
+    const btnLabel = STATE_LABEL[copyState];
+
+    const onClick = () => {
+      setCopyState(copyText(text) ? COPIED : ERRORED);
+      setTimeout(() => setCopyState(NOT_YET), 1000);
+    };
+
+    button.push(
+      <button
+        className={btnClass}
+        style={COPY_STYLE}
+        onClick={onClick}
+        aria-label="copy this text"
+      >
+        {btnLabel}
+      </button>,
+    );
+  }
+
+  return (
+    <pre {...props} style={PRE_STYLE}>
+      {...button}
+      {props.children}
+    </pre>
+  );
+}
+
+function copyText(text: string): boolean {
+  const el = document.createElement('textarea');
+  let result = false;
+  try {
+    el.value = text;
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand('copy');
+    result = true;
+  } catch (err) {
+    /* istanbul ignore next */
+    console.error('failed to copy', err);
+  } finally {
+    el.remove();
+  }
+  return result;
+}

--- a/js/src/components/form.tsx
+++ b/js/src/components/form.tsx
@@ -32,6 +32,7 @@ import {
 } from '../tokens.js';
 import { getConfig, getIdPrefix, initFormProps } from '../utils.js';
 import { CheckItem } from './check-item.js';
+import { MD_OPTIONS } from './markdown.js';
 import { Style } from './style.js';
 
 const FORM_PRE_DEFAULTS: Partial<FormProps> = {
@@ -46,6 +47,7 @@ const SUBMIT_MD_OPTIONS: MarkdownToJSX.Options = {
   forceInline: true,
   forceBlock: false,
   forceWrapper: false,
+  ...MD_OPTIONS,
 };
 
 const BTN_COMMON: Pick<ButtonProps, 'size' | 'className'> = {
@@ -280,7 +282,7 @@ function UrljsfForm(props: IUrljsfFormProps): JSX.Element {
       ? []
       : [
           <li className="list-group-item" key={`${key}-where`}>
-            <Markdown>{tmpl.value}</Markdown>
+            <Markdown options={MD_OPTIONS}>{tmpl.value}</Markdown>
           </li>,
         ];
   };

--- a/js/src/components/markdown.tsx
+++ b/js/src/components/markdown.tsx
@@ -1,0 +1,9 @@
+// Copyright (C) urljsf contributors.
+// Distributed under the terms of the Modified BSD License.
+import type { MarkdownToJSX } from 'markdown-to-jsx';
+
+import { CopyPastePre } from './copy-paste-pre.js';
+
+export const MD_OPTIONS: MarkdownToJSX.Options = {
+  overrides: { pre: CopyPastePre },
+};

--- a/js/src/components/object-template.tsx
+++ b/js/src/components/object-template.tsx
@@ -21,6 +21,7 @@ import Markdown from 'markdown-to-jsx';
 import { UrljsfGridOptions } from '../_props.js';
 import { emptyObject } from '../tokens.js';
 import { useMarkdown } from '../utils.js';
+import { MD_OPTIONS } from './markdown.js';
 
 const DEFAULT_GRID_OPTIONS: UrljsfGridOptions = {
   default: ['col-12'],
@@ -71,7 +72,7 @@ export function ObjectGridTemplate<
 
   let richDescription =
     description && useMarkdown(uiOptions) ? (
-      <Markdown>{description}</Markdown>
+      <Markdown options={MD_OPTIONS}>{description}</Markdown>
     ) : (
       description
     );

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "config": {
       "line-length": false,
       "first-line-h1": false,
-      "no-inline-html": false
+      "no-inline-html": false,
+      "link-fragments": false
     }
   }
 }

--- a/pixi.lock
+++ b/pixi.lock
@@ -2073,7 +2073,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-he02047a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ghp-import-2.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.1.1-py313h46c70d0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
@@ -2176,7 +2175,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-8.1.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-argparse-0.5.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-autobuild-2024.10.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-autodoc-typehints-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-jsonschema-1.19.1-pyhd8ed1ab_0.tar.bz2
@@ -2188,7 +2186,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.36-py313h536fd9c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-0.41.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.1.0-pyhff2d567_0.conda
@@ -2199,11 +2196,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.32.0-pyh31011fe_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/watchdog-6.0.0-py313h78bf25f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-0.24.0-py313h920b4c0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-14.1-py313h536fd9c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wget-1.21.4-hda4d442_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
@@ -2244,7 +2239,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-tools-0.22.5-hdfe23c8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ghp-import-2.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/greenlet-3.1.1-py313h9ea2907_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
@@ -2343,7 +2337,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-8.1.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-argparse-0.5.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-autobuild-2024.10.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-autodoc-typehints-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-jsonschema-1.19.1-pyhd8ed1ab_0.tar.bz2
@@ -2355,7 +2348,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlalchemy-2.0.36-py313hb558fbc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-0.41.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.1.0-pyhff2d567_0.conda
@@ -2366,11 +2358,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.32.0-pyh31011fe_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/watchdog-6.0.0-py313h63b0ddb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/watchfiles-0.24.0-py313h25f93f4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/websockets-14.1-py313h63b0ddb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/wget-1.21.4-hca547e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
@@ -2411,7 +2401,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-tools-0.22.5-h8414b35_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ghp-import-2.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/greenlet-3.1.1-py313h3579c5c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
@@ -2510,7 +2499,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-8.1.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-argparse-0.5.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-autobuild-2024.10.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-autodoc-typehints-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-jsonschema-1.19.1-pyhd8ed1ab_0.tar.bz2
@@ -2522,7 +2510,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlalchemy-2.0.36-py313h63a2874_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-0.41.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.1.0-pyhff2d567_0.conda
@@ -2533,11 +2520,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.32.0-pyh31011fe_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/watchdog-6.0.0-py313h90d716c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/watchfiles-0.24.0-py313h849cdff_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/websockets-14.1-py313h90d716c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wget-1.21.4-he2df1f1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
@@ -2576,7 +2561,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ghp-import-2.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/greenlet-3.1.1-py313h5813708_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
@@ -2719,7 +2703,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-8.1.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-argparse-0.5.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-autobuild-2024.10.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-autodoc-typehints-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-jsonschema-1.19.1-pyhd8ed1ab_0.tar.bz2
@@ -2731,7 +2714,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/sqlalchemy-2.0.36-py313ha7868ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-0.41.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.1.0-pyhff2d567_0.conda
@@ -2743,14 +2725,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.32.0-pyh5737063_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_23.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34433-he29a5d6_23.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34433-hdffcdeb_23.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/watchdog-6.0.0-py313hfa70ccb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/watchfiles-0.24.0-py313hf3b5b86_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/websockets-14.1-py313ha7868ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2

--- a/pixi.toml
+++ b/pixi.toml
@@ -565,7 +565,7 @@ cmd = """cd build/docs
   && python -m http.server -b 127.0.0.1 8101"""
 depends-on = ["docs-sphinx"]
 
-[feature.tasks-docs.tasks.watch-docs]
+[feature.tasks-dev.tasks.watch-docs]
 description = "- watch docs source and rebuild the site"
 cmd = """rm -rf build/watch-docs
   && sphinx-autobuild docs build/watch-docs
@@ -573,9 +573,8 @@ cmd = """rm -rf build/watch-docs
     --jobs 8
     --color
     --watch src
-    --watch pixi.toml
-    --watch js/dist"""
-depends-on = ["docs-pip"]
+    --watch pixi.toml"""
+depends-on = ["dev-pip"]
 
 # envs #########################################################################
 [environments]
@@ -603,11 +602,12 @@ dev = [
   "deps-atest",
   "deps-build",
   "deps-check",
+  "deps-dev",
   "deps-docs",
   "deps-lint",
   "deps-pip",
-  "deps-run",
   "deps-py-max",
+  "deps-run",
   "deps-test",
   "tasks-dev",
 ]
@@ -650,7 +650,6 @@ pydata-sphinx-theme = ">=0.16.0,<0.17.0"
 pypandoc = "*"
 scour = "*"
 sphinx-argparse = "*"
-sphinx-autobuild = "*"
 sphinx-autodoc-typehints = "*"
 sphinx-copybutton = "*"
 sphinx-jsonschema = "*"
@@ -698,6 +697,9 @@ pytest-html = "*"
 twine = "*"
 vale = "*"
 vale-spelling-aoo-mozilla-en-dict-us = "*"
+
+[feature.deps-dev.dependencies]
+sphinx-autobuild = "*"
 
 # tools ########################################################################
 [tool.sphinx]


### PR DESCRIPTION
## References

- fixes #18

## Code changes

- [x] add a `copy` button to all markdown-generated `pre` tags
- [x] add test (isn't _acutally_ checking the clipboard, though)
- [x] update docs
- [x] update changelog

## User-facing changes

- users will see a copy button by all code blocks, which can be used with narrative to describe more complex workflows

## Backwards-incompatible changes

- n/a